### PR TITLE
ci: migrate 10 of 20 jobs to smithy self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
   # Build and test TinyGo implementation
   tinygo-component:
     name: TinyGo Component Build & Test
+    # Stays on hosted: Bazel (not installed on smithy) + macOS matrix.
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -180,6 +181,7 @@ jobs:
   # Integration and cross-component testing
   integration-test:
     name: Integration Testing
+    # Stays on hosted: Bazel is not installed on smithy.
     runs-on: ubuntu-latest
     needs: [tinygo-component]  # rust-component disabled
 
@@ -264,6 +266,7 @@ jobs:
   # Code quality and security checks
   quality-gate:
     name: Quality & Security Gate
+    # Stays on hosted: Bazel (buildifier + bazel run targets) is not installed on smithy.
     runs-on: ubuntu-latest
 
     steps:
@@ -337,7 +340,7 @@ jobs:
   # Documentation build and deployment
   docs-build:
     name: Documentation Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
 
     steps:
     - name: Checkout code
@@ -368,7 +371,7 @@ jobs:
   # Release creation and artifact publishing
   release:
     name: Create Release
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     needs: [tinygo-component, integration-test, quality-gate]  # rust-component disabled
     if: github.event_name == 'release' && github.event.action == 'published'
     permissions:
@@ -428,6 +431,7 @@ jobs:
   # Performance monitoring and metrics
   performance-monitor:
     name: Performance Monitoring
+    # Stays on hosted: Bazel is not installed on smithy.
     runs-on: ubuntu-latest
     needs: [integration-test]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -52,7 +52,7 @@ jobs:
 
   deploy:
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
     needs: build
     environment:
       name: github-pages
@@ -65,7 +65,7 @@ jobs:
   # Also deploy to custom domain if configured
   deploy-custom:
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     needs: build
     steps:
       - name: Checkout

--- a/.github/workflows/oci-publish.yml
+++ b/.github/workflows/oci-publish.yml
@@ -15,6 +15,7 @@ jobs:
   # Build and publish WebAssembly components using rules_wasm_component native publishing
   publish-wasm-components:
     name: Build & Publish WASM Components to OCI
+    # Stays on hosted: Bazel is not installed on smithy.
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -69,6 +70,7 @@ jobs:
   # Publish to WebAssembly package registries using Bazel rules
   publish-wasm-registries:
     name: Publish to WASM Registries
+    # Stays on hosted: Bazel is not installed on smithy.
     runs-on: ubuntu-latest
     needs: [publish-wasm-components]
     if: github.event_name == 'release' || (github.event_name == 'push' && github.ref == 'refs/heads/main')

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -28,6 +28,7 @@ jobs:
   # Performance benchmarking
   performance-benchmark:
     name: Performance Benchmark
+    # Stays on hosted: Bazel + sudo apt + macOS matrix; smithy has none of these.
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -314,6 +315,7 @@ jobs:
   # Memory and resource usage profiling
   resource-profiling:
     name: Resource Usage Profiling
+    # Stays on hosted: Bazel + sudo apt-get install valgrind; not installed on smithy.
     runs-on: ubuntu-latest
 
     steps:
@@ -386,6 +388,7 @@ jobs:
   # Performance regression detection
   regression-detection:
     name: Performance Regression Detection
+    # Stays on hosted: Bazel + sudo dpkg/apt-get; not available on smithy.
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
 jobs:
   build-and-release:
     name: Build & Release WASM Component
+    # Stays on hosted: Bazel + sudo apt-get install build-essential; not available on smithy.
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ jobs:
   # Security vulnerability scanning
   security-scan:
     name: Security Vulnerability Scan
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     permissions:
       contents: read
       security-events: write
@@ -96,7 +96,7 @@ jobs:
   # Dependency vulnerability and license scanning
   dependency-check:
     name: Dependency Security Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
 
     steps:
     - name: Checkout code
@@ -157,7 +157,7 @@ jobs:
   # Automated dependency updates
   dependency-update:
     name: Automated Dependency Updates
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 
     steps:
@@ -256,7 +256,7 @@ jobs:
   # Supply chain security
   supply-chain-security:
     name: Supply Chain Security
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, rust-cpu]
 
     steps:
     - name: Checkout code
@@ -278,7 +278,11 @@ jobs:
       run: |
         # Install SBOM tools - use fixed version for reliability
         SYFT_VERSION="v1.18.1"
-        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin ${SYFT_VERSION}
+        # smithy runner has no write access to /usr/local/bin; install into $HOME/.local/bin
+        mkdir -p "$HOME/.local/bin"
+        curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b "$HOME/.local/bin" ${SYFT_VERSION}
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+        export PATH="$HOME/.local/bin:$PATH"
 
         # Generate SBOM for the repository
         syft . -o spdx-json=sbom.spdx.json -o cyclonedx-json=sbom.cyclonedx.json
@@ -299,8 +303,11 @@ jobs:
       run: |
         # Install cosign for signature verification
         curl -O -L https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
-        sudo mv cosign-linux-amd64 /usr/local/bin/cosign
-        sudo chmod +x /usr/local/bin/cosign
+        # smithy runner has no sudo; install into $HOME/.local/bin and add to PATH
+        mkdir -p "$HOME/.local/bin"
+        mv cosign-linux-amd64 "$HOME/.local/bin/cosign"
+        chmod +x "$HOME/.local/bin/cosign"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
         echo "Signature verification tools installed"
         # Future: Add actual signature verification for dependencies
@@ -308,7 +315,7 @@ jobs:
   # Security policy and compliance
   security-policy:
     name: Security Policy Compliance
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, light]
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Summary

Migrates the no-Bazel CI jobs (npm docs build, security scans, supply-chain
checks, release packaging) from GitHub-hosted runners to the pulseengine
self-hosted fleet managed by [smithy](https://github.com/pulseengine/smithy).
Bazel-using jobs stay on `ubuntu-latest` because Bazel is not yet installed
on the smithy host (tracked in the playbook's out-of-scope table).

Follows the migration playbook
(`smithy/docs/migration-playbook.md`) and matches the conventions used in
`pulseengine/spar#201`, `rivet#262`, `kiln#247`, and `gale#35`.

## Coverage

| Workflow | Job | Class |
|---|---|---|
| ci.yml | docs-build | rust-cpu |
| ci.yml | release | light |
| docs.yml | build | rust-cpu |
| docs.yml | deploy | light |
| docs.yml | deploy-custom | rust-cpu |
| security.yml | security-scan | rust-cpu |
| security.yml | dependency-check | rust-cpu |
| security.yml | dependency-update | rust-cpu |
| security.yml | supply-chain-security | rust-cpu |
| security.yml | security-policy | light |

10 jobs migrated: 7 `rust-cpu`, 3 `light`.

## Stays on hosted

| Job | Reason |
|---|---|
| ci.yml:tinygo-component | Bazel + macOS matrix |
| ci.yml:integration-test | Bazel |
| ci.yml:quality-gate | Bazel (buildifier + `bazel run`) |
| ci.yml:performance-monitor | Bazel |
| oci-publish.yml:publish-wasm-components | Bazel |
| oci-publish.yml:publish-wasm-registries | Bazel |
| performance.yml:performance-benchmark | Bazel + sudo apt + macOS matrix |
| performance.yml:resource-profiling | Bazel + sudo apt-get install valgrind |
| performance.yml:regression-detection | Bazel + sudo dpkg/apt-get |
| release.yml:build-and-release | Bazel + sudo apt-get install build-essential |

Each kept-hosted `runs-on:` has a one-line comment above it naming the reason.

## Workarounds applied

In `security.yml`'s `supply-chain-security` job:

- **cosign install**: rewritten from `sudo mv cosign-linux-amd64 /usr/local/bin/cosign` to `$HOME/.local/bin` + `GITHUB_PATH` (smithy runner has no sudo).
- **syft install**: install script redirected from `-b /usr/local/bin` to `-b $HOME/.local/bin` for the same reason; `GITHUB_PATH` updated.

No other workarounds needed. None of the migrated jobs use `EmbarkStudios/cargo-deny-action`, `rustsec/audit-check`, or `obi1kenobi/cargo-semver-checks-action` — the existing `cargo install cargo-audit` / `cargo install cargo-deny` invocations work directly on smithy.

## Test plan

- [ ] PR's CI completes on the smithy fleet for the migrated jobs (rust-cpu / light)
- [ ] Hosted-only jobs (Bazel + macOS) continue to run on `ubuntu-latest`
- [ ] cosign + syft install steps succeed via `$HOME/.local/bin` workaround on smithy
- [ ] Compare workflow durations vs. previous main runs (sanity check, not blocking)

## Rollback

Revert this commit; every migrated `runs-on:` flips back to `ubuntu-latest` and the workarounds are inert on hosted (the `$HOME/.local/bin` paths still work).